### PR TITLE
Remove NDK abiFilters

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -39,9 +39,6 @@ android {
                 cppFlags "-frtti -fexceptions"
             }
         }
-        ndk {
-            abiFilters 'arm64-v8a', 'x86_64', 'x86'
-        }
     }
     buildTypes {
         debug {


### PR DESCRIPTION
I simply removed the abiFilters. The APK should now include all ABIs. That makes the APK a little bigger, but it will be easier to handle in our development case, as it should run on most devices now.